### PR TITLE
Fix numbering in commit instructions

### DIFF
--- a/.github/steps/2-commit-a-file.md
+++ b/.github/steps/2-commit-a-file.md
@@ -37,9 +37,9 @@ The following steps will guide you through the process of committing a change on
 
    <img width="400" alt="screenshot of adding a new file with a commit message" src="https://github.com/user-attachments/assets/6ab299ce-8039-4734-a707-d7c3cd7077a0">
 
-6. In this lesson, we'll ignore the other fields for now and click **Commit changes**.
+7. In this lesson, we'll ignore the other fields for now and click **Commit changes**.
 
-7. Now that you've changed a file, Mona should already be busy checking your work. Give her a moment and keep watch in the comments. You will see her respond with progress info and the next lesson.
+8. Now that you've changed a file, Mona should already be busy checking your work. Give her a moment and keep watch in the comments. You will see her respond with progress info and the next lesson.
 
 
 <details>


### PR DESCRIPTION
## Summary
- tidy up the numbering in the commit instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a7aa81fc8329b66d43a302639938